### PR TITLE
feat: integrate MCP client/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,30 @@ OPENAI_API_KEY=sk-xxxxx
 
 ## 🐳 Run with Docker Compose
 
-Create a `.env` file with your settings, then Multiple configuration presets are available in the `docs/env-examples` directory:
+Use an env preset before starting Docker Compose:
 
-| File                   | Description                              |
-| ---------------------- | ---------------------------------------- |
-| `.env.inmemory-ollama` | In-memory memory & RAG with Ollama LLM   |
-| `.env.redis-openai`    | Redis memory & LangChain RAG with OpenAI |
+| File                     | Description                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `.env.inmemory-ollama`   | In-memory memory & RAG with Ollama LLM                                           |
+| `.env.redis-openai`      | Redis memory & LangChain RAG with OpenAI                                         |
+| `.env.docker.openai.mcp` | Docker-ready OpenAI + Redis + 3 MCP servers (`localAgent`, `math`, `filesystem`) |
 
 Run with a specific setup:
 
 ```bash
-cp env/.env.redis-openai .env
+cp .env.docker.openai.mcp .env
+# set your real key
+# OPENAI_API_KEY=sk-...
 docker-compose up --build
 ```
+
+The MCP preset includes:
+
+- `localAgent`: this repository local MCP server (`node dist/mcp-server/index.js`)
+- `math`: `@modelcontextprotocol/server-math`
+- `filesystem`: `@modelcontextprotocol/server-filesystem` pointing to `/app/docs`
+
+Note: `math` and `filesystem` use `npx -y ...`, so the container needs outbound internet access on first run.
 
 ## 🧠 Local LLM Setup with Ollama
 
@@ -151,6 +162,48 @@ Notes:
 
 - When `requiresAuth` is `true`, the request includes `Authorization: Bearer <token>` (configurable via the env vars above).
 - Ollama provider currently ignores tools.
+
+## 🔌 MCP Integration
+
+This project now supports MCP tools from remote servers and also exposes local MCP tools over stdio.
+
+### MCP Client env vars
+
+| Variable                          | Description                                                                   | Default         |
+| --------------------------------- | ----------------------------------------------------------------------------- | --------------- |
+| `MCP_SERVERS`                     | JSON object for MCP servers (`stdio`, `sse`, `streamable_http`)               | `""`            |
+| `MCP_TOOL_TIMEOUT`                | Tool timeout in milliseconds                                                  | `20000`         |
+| `MCP_THROW_ON_LOAD_ERROR`         | Throw if tool loading fails                                                   | `true`          |
+| `MCP_USE_STANDARD_CONTENT_BLOCKS` | Normalize responses to standard content blocks                                | `true`          |
+| `MCP_AUTH_TOKEN`                  | Default bearer token for HTTP/SSE MCP servers (if server headers are not set) | `""`            |
+| `MCP_AUTH_HEADER`                 | Header used with `MCP_AUTH_TOKEN`                                             | `Authorization` |
+
+Example:
+
+```env
+MCP_SERVERS='{
+  "local": {
+    "transport": "stdio",
+    "command": "node",
+    "args": ["dist/mcp-server/index.js"],
+    "optional": true
+  }
+}'
+MCP_TOOL_TIMEOUT=20000
+```
+
+Docker/OpenAI preset used by this repository:
+
+```env
+MCP_SERVERS={"localAgent":{"transport":"stdio","command":"node","args":["dist/mcp-server/index.js"],"optional":true},"math":{"transport":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-math"],"optional":true},"filesystem":{"transport":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/app/docs"],"optional":true}}
+```
+
+### Local MCP server scripts
+
+```bash
+npm run build:mcp-server
+npm run start:mcp-server
+```
 
 ## 📡 API Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   redis:
     image: redis/redis-stack-server:latest
@@ -15,25 +13,14 @@ services:
     container_name: ia-agent
     depends_on:
       - redis
+    env_file:
+      - ./.env.docker.openai.mcp
     environment:
-      APP_PORT: ${APP_PORT}
-      LOG_LEVEL: ${LOG_LEVEL}
-      VECTOR_STORE: ${VECTOR_STORE}
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
-      AGENT_MEMORY_TYPE: ${AGENT_MEMORY_TYPE}
-      REDIS_URL: ${REDIS_URL}
-      AGENT_MEMORY_WINDOW: ${AGENT_MEMORY_WINDOW}
-      LLM_PROVIDER: ${LLM_PROVIDER}
-      OLLAMA_ENDPOINT: ${OLLAMA_ENDPOINT}
-      RAG_PROVIDER: ${RAG_PROVIDER}
-      RAG_DOCS_PATH: ${RAG_DOCS_PATH}
-      VECTOR_INDEX_NAME: ${VECTOR_INDEX_NAME}
-      AGENT_PROMPT: ${AGENT_PROMPT}
-      LLM_TOOLS_CONFIG: ${LLM_TOOLS_CONFIG}
+      REDIS_URL: redis://redis:6379
     ports:
-      - "${APP_PORT}:${APP_PORT}"
+      - "${APP_PORT:-3000}:${APP_PORT:-3000}"
     volumes:
-      - ./docs:/app/rag/docs
+      - ./docs:/app/docs
     networks:
       - agent
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "build": "nest build",
+    "build:mcp-server": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "check-types": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "check-format": "pnpm format --list-different",
@@ -14,6 +15,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "start:mcp-server": "node dist/mcp-server/index.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -24,10 +26,12 @@
   "dependencies": {
     "@langchain/community": "^0.3.45",
     "@langchain/core": "^0.3.57",
+    "@langchain/mcp-adapters": "^1.1.3",
     "@langchain/ollama": "^0.2.3",
     "@langchain/openai": "^0.5.11",
     "@langchain/pinecone": "^0.2.0",
     "@langchain/redis": "^0.1.0",
+    "@modelcontextprotocol/sdk": "^1.17.4",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
@@ -46,7 +50,8 @@
     "openai": "^4.100.0",
     "redis": "^4.6.7",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@langchain/core':
         specifier: ^0.3.57
         version: 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49))
+      '@langchain/mcp-adapters':
+        specifier: ^1.1.3
+        version: 1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))(@langchain/langgraph@1.1.5(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))(zod-to-json-schema@3.25.1(zod@3.25.49))(zod@3.25.49))
       '@langchain/ollama':
         specifier: ^0.2.3
         version: 0.2.3(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))
@@ -26,6 +29,9 @@ importers:
       '@langchain/redis':
         specifier: ^0.1.0
         version: 0.1.1(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.4
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.49)
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -83,6 +89,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.49
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -393,6 +402,12 @@ packages:
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@huggingface/jinja@0.2.2':
     resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
@@ -1037,6 +1052,45 @@ packages:
     resolution: {integrity: sha512-jz28qCTKJmi47b6jqhQ6vYRTG5jRpqhtPQjriRTB5wR8mgvzo6xKs0fG/kExS3ZvM79ytD1npBvgf8i19xOo9Q==}
     engines: {node: '>=18'}
 
+  '@langchain/langgraph-checkpoint@1.0.0':
+    resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.0.1
+
+  '@langchain/langgraph-sdk@2.0.0':
+    resolution: {integrity: sha512-Xdkl1hve84ZGQ7fgpiBIBvjODhtjbPPccY4snOtYgSdzRXZkESsi2Y7RDKgFe1nC9+DbX+QaYom0raD/XFBKAw==}
+    deprecated: This version is not intended for use. Please use 1.x versions of @langchain/langgraph-sdk instead
+    peerDependencies:
+      '@langchain/core': ^1.1.16
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@langchain/langgraph@1.1.5':
+    resolution: {integrity: sha512-uJC/asydf/GoHpo9x42lf9hs8ufCkMuJ9sDle5ybP7sMD0XryOfE0E4J3deARk9ZadCCt6zeCoCNu/mTbx8+Sg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.16
+      zod: ^3.25.32 || ^4.2.0
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
+  '@langchain/mcp-adapters@1.1.3':
+    resolution: {integrity: sha512-OPHIQNkTUJjnRj1pr+cp2nguMBZeF3Q1pVT1hCbgU7BrHgV7lov99wbU8po8Cm4zZzmeRtVO/T9X1SrDD1ogtQ==}
+    engines: {node: '>=20.10.0'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
+      '@langchain/langgraph': ^1.0.0
+
   '@langchain/ollama@0.2.3':
     resolution: {integrity: sha512-1Obe45jgQspqLMBVlayQbGdywFmri8DgmGRdzNu0li56cG5RReYlRCFVDZBRMMvF9JhsP5eXRyfyivtKfITHWQ==}
     engines: {node: '>=18'}
@@ -1084,6 +1138,16 @@ packages:
 
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
+  '@modelcontextprotocol/sdk@1.26.0':
+    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/saslprep@1.2.2':
     resolution: {integrity: sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==}
@@ -1299,6 +1363,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -1577,6 +1644,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1597,6 +1668,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -1762,6 +1841,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -1974,6 +2057,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -1983,6 +2070,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -2035,6 +2126,15 @@ packages:
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -2302,9 +2402,20 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2325,12 +2436,25 @@ packages:
   expr-eval@2.0.2:
     resolution: {integrity: sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==}
 
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extended-eventsource@1.7.0:
+    resolution: {integrity: sha512-s8rtvZuYcKBpzytHb5g95cHbZ1J99WeMnV18oKc5wKoxkHzlzpPc/bNAm7Da2Db0BDw0CAu1z3LpH+7UsyzIpw==}
 
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -2396,6 +2520,10 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2470,6 +2598,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2612,11 +2744,19 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.2:
+    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   human-signals@2.1.0:
@@ -2632,6 +2772,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -2676,6 +2820,10 @@ packages:
     resolution: {integrity: sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==}
     engines: {node: '>=12.22.0'}
 
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2714,6 +2862,10 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-network-error@1.3.0:
+    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+    engines: {node: '>=16'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -2721,6 +2873,9 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -2908,6 +3063,9 @@ packages:
       node-notifier:
         optional: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tiktoken@1.0.20:
     resolution: {integrity: sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==}
 
@@ -2938,6 +3096,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3156,6 +3317,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -3165,6 +3330,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3185,9 +3354,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -3307,6 +3484,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -3465,13 +3646,25 @@ packages:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
 
+  p-queue@9.1.0:
+    resolution: {integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==}
+    engines: {node: '>=20'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3517,6 +3710,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3543,6 +3739,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -3634,6 +3834,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
@@ -3650,6 +3854,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -3754,6 +3962,10 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -3809,6 +4021,10 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
@@ -3819,6 +4035,10 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -3917,6 +4137,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   streamsearch@1.1.0:
@@ -4032,6 +4256,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.14:
     resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
@@ -4204,6 +4429,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
@@ -4268,6 +4497,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
   uuid@9.0.1:
@@ -4426,8 +4659,16 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
   zod@3.25.49:
     resolution: {integrity: sha512-JMMPMy9ZBk3XFEdbM3iL1brx4NUSejd6xr3ELrrGEfGb355gjhiAWtG3K5o+AViV/3ZfkIrCzXsZn6SbLwTR8Q==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -4747,6 +4988,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.3
       yargs: 17.7.2
+
+  '@hono/node-server@1.19.9(hono@4.12.2)':
+    dependencies:
+      hono: 4.12.2
 
   '@huggingface/jinja@0.2.2': {}
 
@@ -5146,6 +5391,47 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))':
+    dependencies:
+      '@langchain/core': 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49))
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@2.0.0(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.0
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      '@langchain/core': 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49))
+
+  '@langchain/langgraph@1.1.5(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))(zod-to-json-schema@3.25.1(zod@3.25.49))(zod@3.25.49)':
+    dependencies:
+      '@langchain/core': 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))
+      '@langchain/langgraph-sdk': 2.0.0(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 3.25.49
+    optionalDependencies:
+      zod-to-json-schema: 3.25.1(zod@3.25.49)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@langchain/mcp-adapters@1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))(@langchain/langgraph@1.1.5(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))(zod-to-json-schema@3.25.1(zod@3.25.49))(zod@3.25.49))':
+    dependencies:
+      '@langchain/core': 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49))
+      '@langchain/langgraph': 1.1.5(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))(zod-to-json-schema@3.25.1(zod@3.25.49))(zod@3.25.49)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      debug: 4.4.3
+      zod: 3.25.76
+    optionalDependencies:
+      extended-eventsource: 1.7.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@langchain/ollama@0.2.3(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49)))':
     dependencies:
       '@langchain/core': 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.25.49))
@@ -5195,6 +5481,54 @@ snapshots:
   '@lukeed/csprng@1.1.0': {}
 
   '@microsoft/tsdoc@0.15.1': {}
+
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.49)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.2)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.2
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.49
+      zod-to-json-schema: 3.25.1(zod@3.25.49)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.2)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.2
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/saslprep@1.2.2':
     dependencies:
@@ -5425,6 +5759,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -5794,6 +6130,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
@@ -5813,6 +6154,10 @@ snapshots:
       ajv: 8.12.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
@@ -6007,6 +6352,20 @@ snapshots:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6216,11 +6575,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.1: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.6: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.1: {}
 
@@ -6278,6 +6641,10 @@ snapshots:
       ms: 2.0.0
 
   debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -6519,7 +6886,15 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventemitter3@5.0.4: {}
+
   events@3.3.0: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
 
   execa@5.1.1:
     dependencies:
@@ -6546,6 +6921,11 @@ snapshots:
       jest-util: 29.7.0
 
   expr-eval@2.0.2: {}
+
+  express-rate-limit@8.2.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.0.1
 
   express@4.21.2:
     dependencies:
@@ -6583,7 +6963,43 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.0
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend@3.0.2: {}
+
+  extended-eventsource@1.7.0:
+    optional: true
 
   external-editor@3.1.0:
     dependencies:
@@ -6663,6 +7079,17 @@ snapshots:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6751,6 +7178,8 @@ snapshots:
       trigram-utils: 2.0.1
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -6897,6 +7326,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.2: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.0:
@@ -6905,6 +7336,14 @@ snapshots:
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
       toidentifier: 1.0.1
 
   human-signals@2.1.0: {}
@@ -6934,6 +7373,10 @@ snapshots:
       - supports-color
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -7013,6 +7456,8 @@ snapshots:
       - supports-color
     optional: true
 
+  ip-address@10.0.1: {}
+
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
@@ -7039,9 +7484,13 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-network-error@1.3.0: {}
+
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -7424,6 +7873,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  jose@6.1.3: {}
+
   js-tiktoken@1.0.20:
     dependencies:
       base64-js: 1.5.1
@@ -7448,6 +7899,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -7624,6 +8077,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.0.6
@@ -7632,6 +8087,8 @@ snapshots:
     optional: true
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -7646,9 +8103,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -7732,6 +8195,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -7907,14 +8372,25 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
+  p-queue@9.1.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.0
+
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
 
@@ -7950,6 +8426,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
 
   peek-readable@4.1.0: {}
@@ -7963,6 +8441,8 @@ snapshots:
   picomatch@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -8077,6 +8557,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
@@ -8092,6 +8576,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -8205,6 +8696,16 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-async@2.4.1: {}
 
   run-async@3.0.0: {}
@@ -8267,6 +8768,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
@@ -8282,6 +8799,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8426,6 +8952,8 @@ snapshots:
     optional: true
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   streamsearch@1.1.0: {}
 
@@ -8739,6 +9267,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typedarray@0.0.6: {}
 
   typescript@5.7.2: {}
@@ -8783,6 +9317,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
+
+  uuid@13.0.0: {}
 
   uuid@9.0.1: {}
 
@@ -8944,4 +9480,14 @@ snapshots:
     dependencies:
       zod: 3.25.49
 
+  zod-to-json-schema@3.25.1(zod@3.25.49):
+    dependencies:
+      zod: 3.25.49
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod@3.25.49: {}
+
+  zod@3.25.76: {}

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -75,6 +75,34 @@ export default registerAs('appConfig', () => ({
    */
   toolsAuthToken: process.env.LLM_TOOLS_AUTH_TOKEN || '',
 
+  // MCP (Model Context Protocol) Settings
+  /**
+   * JSON string with MCP server definitions consumed by MultiServerMCPClient.
+   * Example:
+   *  MCP_SERVERS='{"filesystem":{"transport":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","."]}}'
+   */
+  mcpServersRaw: process.env.MCP_SERVERS || '',
+  /**
+   * Timeout in milliseconds for MCP tool operations.
+   * Default: 20000
+   */
+  mcpToolTimeout: parseInt(process.env.MCP_TOOL_TIMEOUT || '20000', 10),
+  /**
+   * If true, MCP client throws when a server fails to load.
+   * Default: true
+   */
+  mcpThrowOnLoadError: process.env.MCP_THROW_ON_LOAD_ERROR !== 'false',
+  /**
+   * If true, MCP responses are normalized into LangChain standard blocks.
+   * Default: true
+   */
+  mcpUseStandardContentBlocks: process.env.MCP_USE_STANDARD_CONTENT_BLOCKS !== 'false',
+  /**
+   * Default token/header used for MCP HTTP/SSE servers when configured.
+   */
+  mcpAuthToken: process.env.MCP_AUTH_TOKEN || '',
+  mcpAuthHeader: process.env.MCP_AUTH_HEADER || 'Authorization',
+
   // RAG (Retrieval Augmented Generation) Settings
   /**
    * RAG provider selection. "InMemoryRagProvider" (inMemory) or "langchain" (LangchainRagProvider).

--- a/src/llm/llm.module.ts
+++ b/src/llm/llm.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common'
 import { LlmService } from './llm.service'
 import { ToolsService } from './tools/tools.service'
+import { McpModule } from '../mcp/mcp.module'
 
 @Module({
+  imports: [McpModule],
   providers: [LlmService, ToolsService],
   exports: [LlmService, ToolsService],
 })

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -1,10 +1,12 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { LlmProvider } from './interfaces/llm-provider.interface'
 import { OpenAiProvider } from './providers/openai.provider'
 import { OllamaProvider } from './providers/ollama.provider'
 import { detectLanguage } from '../common/utils/lang-detect.util'
 import { ToolsService } from './tools/tools.service'
+import { McpClientService } from '../mcp/mcp-client.service'
+import type { StructuredToolInterface } from '@langchain/core/tools'
 
 /**
  * Service responsible for instantiating and delegating to a concrete LLM provider.
@@ -16,13 +18,14 @@ import { ToolsService } from './tools/tools.service'
  * for visibility.
  */
 @Injectable()
-export class LlmService implements OnModuleInit {
+export class LlmService implements OnModuleInit, OnModuleDestroy {
   /** Selected LLM provider implementation. */
   private provider: LlmProvider
   /** Agent prompt prefix loaded from configuration. */
   private readonly agentPrompt: string
   /** Internal logger instance. */
   private readonly logger = new Logger(LlmService.name)
+  private combinedTools: StructuredToolInterface[] = []
 
   /**
    * Constructs the LLM service.
@@ -32,6 +35,7 @@ export class LlmService implements OnModuleInit {
   constructor(
     private readonly configService: ConfigService,
     private readonly toolsService: ToolsService,
+    private readonly mcpClientService: McpClientService,
   ) {
     // Load the agent prompt.  This provides high‑level instructions for the
     // assistant and should be kept concise.
@@ -59,16 +63,26 @@ export class LlmService implements OnModuleInit {
     this.logger.debug(`Agent prompt loaded: "${this.agentPrompt}"`)
   }
 
-  onModuleInit() {
+  async onModuleInit(): Promise<void> {
     // Initialize tools at module init and print their names
     try {
-      const tools = this.toolsService.getTools()
+      const internalTools = this.toolsService.getTools() as StructuredToolInterface[]
+      const mcpTools = await this.mcpClientService.loadTools().catch((error: unknown) => {
+        this.logger.error(`Failed to load MCP tools: ${(error as Error).message}`)
+        return []
+      })
+      const tools = [...internalTools, ...mcpTools]
+      this.combinedTools = tools
       const names = tools.map((t) => t.name).join(', ')
       this.logger.log(`Tools initialized: ${tools.length} tool(s) available to the LLM`)
       if (names.length > 0) this.logger.log(`Tools: ${names}`)
     } catch (e) {
       this.logger.error(`Failed to initialize tools on module init: ${(e as Error).message}`)
     }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.mcpClientService.close()
   }
 
   /**
@@ -108,7 +122,12 @@ export class LlmService implements OnModuleInit {
     const prompt = this.buildPrompt(userMessage, { userLang: lang })
     this.logger.debug(`Sending prompt to provider: "${prompt}"`)
     try {
-      const tools = this.toolsService.getTools()
+      const tools =
+        this.combinedTools.length > 0
+          ? this.combinedTools
+          : ((this.toolsService.getTools() as StructuredToolInterface[]).concat(
+              await this.mcpClientService.loadTools().catch(() => []),
+            ) as StructuredToolInterface[])
       this.logger.debug(`Available tools: ${tools.map((t) => t.name).join(', ')}`)
       const result = await this.provider.generate(prompt, { ...options, userLang: lang, tools })
       this.logger.debug('LLM provider returned response.')

--- a/src/llm/providers/openai.provider.ts
+++ b/src/llm/providers/openai.provider.ts
@@ -60,9 +60,7 @@ export class OpenAiProvider implements LlmProvider {
       this.logger.log(`OpenAI tool-calling engaged with ${options.tools.length} tool(s).`)
       let aiMsg: AIMessage = await bound.invoke(messages)
       // Loop while model requests tool calls
-      while (
-        Array.isArray((aiMsg as any).tool_calls) && ((aiMsg as any).tool_calls as any[]).length > 0
-      ) {
+      while (Array.isArray((aiMsg as any).tool_calls) && ((aiMsg as any).tool_calls as any[]).length > 0) {
         const toolCalls = (aiMsg as any).tool_calls as any[]
         // Include the AI tool-call message in history
         messages.push(aiMsg)

--- a/src/llm/tools/types.ts
+++ b/src/llm/tools/types.ts
@@ -13,4 +13,3 @@ export interface ToolsAuthConfig {
   scheme?: string // Default: Bearer
   token?: string // Required if any tool requiresAuth = true
 }
-

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -1,0 +1,80 @@
+import { Logger } from '@nestjs/common'
+import { NestFactory } from '@nestjs/core'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { ZodError } from 'zod'
+import { McpServerModule } from './mcp-server.module'
+import { RagService } from '../rag/rag.service'
+import { MemoryService } from '../memory/memory.service'
+import { listLocalMcpTools, runLocalMcpTool } from './tools'
+
+async function bootstrapMcpServer() {
+  const logger = new Logger('LocalMcpServer')
+  const app = await NestFactory.createApplicationContext(McpServerModule, {
+    logger: ['error', 'warn', 'log'],
+  })
+
+  const ragService = app.get(RagService)
+  const memoryService = app.get(MemoryService)
+
+  const server = new Server(
+    {
+      name: 'ai-agent-nestjs-local-mcp',
+      version: '0.0.1',
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  )
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: listLocalMcpTools(),
+  }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolName = request.params.name
+    try {
+      const payload = await runLocalMcpTool(toolName, request.params.arguments ?? {}, {
+        ragService,
+        memoryService,
+      })
+      return {
+        content: [{ type: 'text', text: payload }],
+      }
+    } catch (error) {
+      const message =
+        error instanceof ZodError
+          ? `Invalid tool input: ${error.issues.map((i) => i.message).join('; ')}`
+          : (error as Error).message
+      logger.error(`Tool "${toolName}" failed: ${message}`)
+      return {
+        isError: true,
+        content: [{ type: 'text', text: message }],
+      }
+    }
+  })
+
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+  logger.log('Local MCP server running on stdio transport.')
+
+  const shutdown = async () => {
+    try {
+      await app.close()
+    } finally {
+      process.exit(0)
+    }
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}
+
+bootstrapMcpServer().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to start local MCP server:', error)
+  process.exit(1)
+})

--- a/src/mcp-server/mcp-server.module.ts
+++ b/src/mcp-server/mcp-server.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import appConfig from '../config/app-config'
+import { MemoryModule } from '../memory/memory.module'
+import { RagModule } from '../rag/rag.module'
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      envFilePath: '.env',
+      load: [appConfig],
+      isGlobal: true,
+    }),
+    RagModule,
+    MemoryModule,
+  ],
+})
+export class McpServerModule {}

--- a/src/mcp-server/tools.ts
+++ b/src/mcp-server/tools.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod'
+import { RagService } from '../rag/rag.service'
+import { MemoryService } from '../memory/memory.service'
+
+const queryRagInputSchema = z.object({
+  query: z.string().min(1),
+})
+
+const getMemoryHistoryInputSchema = z.object({
+  sessionId: z.string().min(1),
+})
+
+const addMemoryMessageInputSchema = z.object({
+  sessionId: z.string().min(1),
+  role: z.enum(['user', 'assistant']),
+  content: z.string().min(1),
+})
+
+const clearMemoryInputSchema = z.object({
+  sessionId: z.string().min(1),
+})
+
+export type LocalMcpToolName = 'queryRag' | 'getMemoryHistory' | 'addMemoryMessage' | 'clearMemory'
+
+export function listLocalMcpTools() {
+  return [
+    {
+      name: 'queryRag',
+      description: 'Searches the RAG context provider and returns relevant document snippets.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Natural language query for document retrieval.' },
+        },
+        required: ['query'],
+      },
+    },
+    {
+      name: 'getMemoryHistory',
+      description: 'Returns stored conversation history for a session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string', description: 'Session identifier.' },
+        },
+        required: ['sessionId'],
+      },
+    },
+    {
+      name: 'addMemoryMessage',
+      description: 'Appends a message to session memory.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string', description: 'Session identifier.' },
+          role: { type: 'string', enum: ['user', 'assistant'] },
+          content: { type: 'string', description: 'Message content.' },
+        },
+        required: ['sessionId', 'role', 'content'],
+      },
+    },
+    {
+      name: 'clearMemory',
+      description: 'Clears stored messages for a session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string', description: 'Session identifier.' },
+        },
+        required: ['sessionId'],
+      },
+    },
+  ]
+}
+
+export async function runLocalMcpTool(
+  toolName: string,
+  args: unknown,
+  dependencies: { ragService: RagService; memoryService: MemoryService },
+): Promise<string> {
+  const { ragService, memoryService } = dependencies
+
+  switch (toolName as LocalMcpToolName) {
+    case 'queryRag': {
+      const { query } = queryRagInputSchema.parse(args ?? {})
+      const contexts = await ragService.retrieveContext(query)
+      return JSON.stringify({ query, contexts })
+    }
+    case 'getMemoryHistory': {
+      const { sessionId } = getMemoryHistoryInputSchema.parse(args ?? {})
+      const history = await memoryService.getHistory(sessionId)
+      return JSON.stringify({ sessionId, history })
+    }
+    case 'addMemoryMessage': {
+      const { sessionId, role, content } = addMemoryMessageInputSchema.parse(args ?? {})
+      await memoryService.addMessage(sessionId, role, content)
+      return JSON.stringify({ ok: true, sessionId, role })
+    }
+    case 'clearMemory': {
+      const { sessionId } = clearMemoryInputSchema.parse(args ?? {})
+      await memoryService.clear(sessionId)
+      return JSON.stringify({ ok: true, sessionId })
+    }
+    default:
+      throw new Error(`Unknown MCP tool: ${toolName}`)
+  }
+}

--- a/src/mcp/__tests__/mcp-client.service.spec.ts
+++ b/src/mcp/__tests__/mcp-client.service.spec.ts
@@ -1,0 +1,108 @@
+import { ConfigService } from '@nestjs/config'
+import { McpClientService } from '../mcp-client.service'
+
+const mockGetTools = jest.fn()
+const mockClose = jest.fn()
+
+jest.mock('@langchain/mcp-adapters', () => ({
+  MultiServerMCPClient: jest.fn().mockImplementation(() => ({
+    getTools: mockGetTools,
+    close: mockClose,
+  })),
+}))
+
+const { MultiServerMCPClient: mockMcpClientCtor } = jest.requireMock('@langchain/mcp-adapters') as {
+  MultiServerMCPClient: jest.Mock
+}
+
+describe('McpClientService', () => {
+  const configValues: Record<string, unknown> = {
+    'appConfig.mcpServersRaw': JSON.stringify({
+      optionalRemote: {
+        transport: 'sse',
+        url: 'https://mcp.example.com/sse',
+        optional: true,
+      },
+      localStdio: {
+        transport: 'stdio',
+        command: 'node',
+        args: ['dist/mcp-server/index.js'],
+      },
+    }),
+    'appConfig.mcpThrowOnLoadError': true,
+    'appConfig.mcpUseStandardContentBlocks': true,
+    'appConfig.mcpAuthToken': 'token-123',
+    'appConfig.mcpAuthHeader': 'Authorization',
+  }
+
+  let service: McpClientService
+  let configService: Pick<ConfigService, 'get'>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    configService = {
+      get: jest.fn((key: string, defaultValue?: unknown) =>
+        Object.prototype.hasOwnProperty.call(configValues, key) ? configValues[key] : defaultValue,
+      ),
+    }
+    service = new McpClientService(configService as ConfigService)
+  })
+
+  it('loads tools and returns them by name', async () => {
+    const remoteTool = { name: 'remoteLookup' }
+    mockGetTools.mockResolvedValue([remoteTool])
+
+    const tools = await service.loadTools()
+
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe('remoteLookup')
+    expect(service.getTool('remoteLookup')).toBe(remoteTool)
+    expect(mockMcpClientCtor).toHaveBeenCalledTimes(1)
+  })
+
+  it('builds MCP client with expected options and tool hooks', async () => {
+    mockGetTools.mockResolvedValue([])
+    await service.loadTools()
+
+    const constructorOptions = mockMcpClientCtor.mock.calls[0][0]
+    expect(constructorOptions.throwOnLoadError).toBe(true)
+    expect(constructorOptions.useStandardContentBlocks).toBe(true)
+    expect(constructorOptions.mcpServers.optionalRemote.headers.Authorization).toBe('Bearer token-123')
+    expect(constructorOptions.mcpServers.localStdio.restart.enabled).toBe(true)
+
+    const before = constructorOptions.beforeToolCall({
+      name: 'remoteLookup',
+      args: { query: 'nestjs' },
+      serverName: 'optionalRemote',
+    })
+    expect(before.args.query).toBe('nestjs')
+    expect(before.args.requestId).toBeDefined()
+
+    const after = constructorOptions.afterToolCall({
+      name: 'remoteLookup',
+      result: [{ type: 'text', text: 'ok' }],
+      serverName: 'optionalRemote',
+    })
+    expect(after).toEqual({ result: [{ type: 'text', text: 'ok' }] })
+
+    expect(() =>
+      constructorOptions.onConnectionError({ error: new Error('offline'), serverName: 'optionalRemote' }),
+    ).not.toThrow()
+  })
+
+  it('closes MCP client gracefully', async () => {
+    mockGetTools.mockResolvedValue([])
+    await service.loadTools()
+    await service.close()
+    expect(mockClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails when MCP_SERVERS is invalid JSON', async () => {
+    ;(configService.get as jest.Mock).mockImplementation((key: string, defaultValue?: unknown) => {
+      if (key === 'appConfig.mcpServersRaw') return '{invalid-json}'
+      return Object.prototype.hasOwnProperty.call(configValues, key) ? configValues[key] : defaultValue
+    })
+    const invalidService = new McpClientService(configService as ConfigService)
+    await expect(invalidService.loadTools()).rejects.toThrow('MCP_SERVERS has invalid JSON')
+  })
+})

--- a/src/mcp/__tests__/mcp-server.tools.spec.ts
+++ b/src/mcp/__tests__/mcp-server.tools.spec.ts
@@ -1,0 +1,44 @@
+import { listLocalMcpTools, runLocalMcpTool } from '../../mcp-server/tools'
+
+describe('local MCP server tools', () => {
+  it('lists the expected tool names', () => {
+    const names = listLocalMcpTools().map((tool) => tool.name)
+    expect(names).toEqual(['queryRag', 'getMemoryHistory', 'addMemoryMessage', 'clearMemory'])
+  })
+
+  it('runs queryRag tool', async () => {
+    const ragService = {
+      retrieveContext: jest.fn().mockResolvedValue(['doc 1', 'doc 2']),
+    }
+    const memoryService = {
+      getHistory: jest.fn(),
+      addMessage: jest.fn(),
+      clear: jest.fn(),
+    }
+
+    const result = await runLocalMcpTool('queryRag', { query: 'what is nestjs' }, { ragService, memoryService } as any)
+    const parsed = JSON.parse(result)
+
+    expect(parsed.query).toBe('what is nestjs')
+    expect(parsed.contexts).toEqual(['doc 1', 'doc 2'])
+    expect(ragService.retrieveContext).toHaveBeenCalledWith('what is nestjs')
+  })
+
+  it('validates addMemoryMessage tool input', async () => {
+    const ragService = {
+      retrieveContext: jest.fn(),
+    }
+    const memoryService = {
+      getHistory: jest.fn(),
+      addMessage: jest.fn(),
+      clear: jest.fn(),
+    }
+
+    await expect(
+      runLocalMcpTool('addMemoryMessage', { sessionId: 's1', role: 'invalid', content: 'hello' }, {
+        ragService,
+        memoryService,
+      } as any),
+    ).rejects.toThrow()
+  })
+})

--- a/src/mcp/mcp-client.service.ts
+++ b/src/mcp/mcp-client.service.ts
@@ -1,0 +1,182 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { MultiServerMCPClient } from '@langchain/mcp-adapters'
+import { EventEmitter } from 'events'
+import { randomUUID } from 'crypto'
+import type { StructuredToolInterface } from '@langchain/core/tools'
+
+type McpTransport = 'stdio' | 'sse' | 'http'
+
+type McpServerConfig = {
+  transport: McpTransport
+  type?: McpTransport
+  command?: string
+  args?: string[]
+  url?: string
+  headers?: Record<string, string>
+  defaultToolTimeout?: number
+  optional?: boolean
+  restart?: {
+    enabled?: boolean
+    maxAttempts?: number
+    delayMs?: number
+  }
+}
+
+type McpServersConfig = Record<string, McpServerConfig>
+
+@Injectable()
+export class McpClientService implements OnModuleDestroy {
+  private readonly logger = new Logger(McpClientService.name)
+  private readonly eventBus = new EventEmitter()
+  private readonly optionalServers = new Set<string>()
+  private client: MultiServerMCPClient | null = null
+  private toolsByName = new Map<string, StructuredToolInterface>()
+
+  constructor(private readonly configService: ConfigService) {}
+
+  get events(): EventEmitter {
+    return this.eventBus
+  }
+
+  async loadTools(): Promise<StructuredToolInterface[]> {
+    const hasServers = this.configService.get<string>('appConfig.mcpServersRaw', '').trim().length > 0
+    if (!hasServers) {
+      this.logger.debug('No MCP_SERVERS configured; skipping MCP tool loading.')
+      return []
+    }
+    const client = this.getOrCreateClient()
+    const tools = await client.getTools()
+    this.toolsByName = new Map(tools.map((tool) => [tool.name, tool]))
+    this.eventBus.emit('progress', {
+      type: 'tools_loaded',
+      count: tools.length,
+      names: tools.map((tool) => tool.name),
+    })
+    this.logger.log(`Loaded ${tools.length} MCP tool(s): ${tools.map((tool) => tool.name).join(', ')}`)
+    return tools
+  }
+
+  getTool(name: string): StructuredToolInterface | undefined {
+    return this.toolsByName.get(name)
+  }
+
+  async close(): Promise<void> {
+    if (!this.client) return
+    await this.client.close()
+    this.client = null
+    this.toolsByName.clear()
+    this.logger.log('MCP client closed.')
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.close()
+  }
+
+  private getOrCreateClient(): MultiServerMCPClient {
+    if (this.client) return this.client
+
+    const mcpServers = this.readMcpServers()
+    this.client = new MultiServerMCPClient({
+      mcpServers: mcpServers as Record<string, any>,
+      throwOnLoadError: this.configService.get<boolean>('appConfig.mcpThrowOnLoadError', true),
+      useStandardContentBlocks: this.configService.get<boolean>('appConfig.mcpUseStandardContentBlocks', true),
+      onConnectionError: ({ error, serverName }: { error: unknown; serverName: string }) => {
+        const message = error instanceof Error ? error.message : String(error)
+        if (this.optionalServers.has(serverName)) {
+          this.logger.warn(`Optional MCP server "${serverName}" is unavailable: ${message}`)
+          this.eventBus.emit('message', {
+            level: 'warn',
+            serverName,
+            optional: true,
+            message,
+          })
+          return
+        }
+        this.logger.error(`MCP server "${serverName}" connection error: ${message}`)
+        this.eventBus.emit('message', {
+          level: 'error',
+          serverName,
+          optional: false,
+          message,
+        })
+      },
+      beforeToolCall: (toolCall: { args: unknown; name: string; serverName: string }) => {
+        const requestId = randomUUID()
+        const args =
+          typeof toolCall.args === 'object' && toolCall.args !== null
+            ? { ...(toolCall.args as Record<string, unknown>), requestId }
+            : { input: toolCall.args, requestId }
+        this.eventBus.emit('progress', {
+          type: 'before_tool_call',
+          requestId,
+          toolName: toolCall.name,
+          serverName: toolCall.serverName,
+        })
+        return { args }
+      },
+      afterToolCall: (res: { name: string; serverName: string; result: unknown }) => {
+        let normalized = res.result
+        if (Array.isArray(normalized)) {
+          normalized = normalized.map((block) => {
+            if ((block as any)?.type === 'text' && typeof (block as any).text !== 'string') {
+              return { ...(block as any), text: JSON.stringify((block as any).text) }
+            }
+            return block
+          })
+        } else if (typeof normalized === 'object' && normalized !== null) {
+          normalized = JSON.stringify(normalized)
+        }
+        this.eventBus.emit('progress', {
+          type: 'after_tool_call',
+          toolName: res.name,
+          serverName: res.serverName,
+          resultBlocks: Array.isArray(normalized) ? normalized.length : 1,
+        })
+        return { result: normalized }
+      },
+    })
+
+    return this.client
+  }
+
+  private readMcpServers(): McpServersConfig {
+    const raw = this.configService.get<string>('appConfig.mcpServersRaw', '').trim()
+    if (!raw) return {}
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch (error) {
+      throw new Error(`MCP_SERVERS has invalid JSON: ${(error as Error).message}`)
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('MCP_SERVERS must be a JSON object keyed by server name.')
+    }
+
+    const servers = parsed as McpServersConfig
+    const defaultToken = this.configService.get<string>('appConfig.mcpAuthToken', '')
+    const defaultHeader = this.configService.get<string>('appConfig.mcpAuthHeader', 'Authorization')
+    const defaultTimeout = this.configService.get<number>('appConfig.mcpToolTimeout', 20000)
+
+    Object.entries(servers).forEach(([name, config]) => {
+      config.defaultToolTimeout = config.defaultToolTimeout ?? defaultTimeout
+      if (config.optional) this.optionalServers.add(name)
+      if (config.transport !== 'stdio') {
+        config.headers ??= {}
+        if (defaultToken && !config.headers[defaultHeader]) {
+          config.headers[defaultHeader] = `Bearer ${defaultToken}`
+        }
+      } else {
+        config.restart = {
+          enabled: config.restart?.enabled ?? true,
+          maxAttempts: config.restart?.maxAttempts ?? 3,
+          delayMs: config.restart?.delayMs ?? 1000,
+        }
+      }
+    })
+
+    return servers
+  }
+}

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { McpClientService } from './mcp-client.service'
+
+@Module({
+  providers: [McpClientService],
+  exports: [McpClientService],
+})
+export class McpModule {}


### PR DESCRIPTION
## Summary
This PR delivers the end-to-end MCP integration in the NestJS backend, including:

- MCP client support to load tools from external MCP servers
- A local MCP server exposing internal app capabilities (RAG + memory)
- Agent/LLM integration so MCP tools are available at runtime
- Docker/OpenAI preset with 3 MCP servers ready to test (`localAgent`, `math`, `filesystem`)
- Updated documentation and MCP test coverage

## What was added

### 1) MCP client integration
- Added `McpClientService` to:
  - Read MCP server config from env (`MCP_SERVERS`)
  - Initialize `MultiServerMCPClient` with:
    - `throwOnLoadError`
    - `useStandardContentBlocks`
    - `onConnectionError`
    - `beforeToolCall` / `afterToolCall`
  - Load and cache tools (`getTools()` path)
  - Expose `loadTools()`, `getTool(name)`, and `close()`
  - Emit progress/message events via `EventEmitter`
- Added `McpModule` for DI/export.

### 2) LLM runtime wiring
- `LlmService` now injects `McpClientService`
- On init, internal tools + MCP tools are combined and logged
- On shutdown, MCP client connections are closed gracefully
- Preserved existing provider behavior (OpenAI/Ollama) while extending tool availability.

### 3) Local MCP server
- Added `src/mcp-server` with:
  - MCP bootstrap server over stdio
  - `ListToolsRequestSchema` and `CallToolRequestSchema` handlers
  - Tool definitions + Zod validation
- Exposed local tools:
  - `queryRag`
  - `getMemoryHistory`
  - `addMemoryMessage`
  - `clearMemory`

### 4) Configuration and scripts
- Added dependencies:
  - `@langchain/mcp-adapters`
  - `@modelcontextprotocol/sdk`
  - `zod`
- Added scripts:
  - `build:mcp-server`
  - `start:mcp-server`
- Extended app config with MCP env vars:
  - `MCP_SERVERS`
  - `MCP_TOOL_TIMEOUT`
  - `MCP_THROW_ON_LOAD_ERROR`
  - `MCP_USE_STANDARD_CONTENT_BLOCKS`
  - `MCP_AUTH_TOKEN`
  - `MCP_AUTH_HEADER`

### 5) Docker/OpenAI MCP preset
- Added `.env.docker.openai.mcp` with OpenAI + Redis + 3 MCP servers:
  - `localAgent` (repo local server)
  - `math`
  - `filesystem` (`/app/docs`)
- Updated `docker-compose.yml` to:
  - Use the MCP env preset
  - Mount docs at `/app/docs`
  - Use robust APP_PORT default mapping
  - Use Redis service URL inside the network.

### 6) Tests and quality
- Added MCP-focused tests:
  - `src/mcp/__tests__/mcp-client.service.spec.ts`
  - `src/mcp/__tests__/mcp-server.tools.spec.ts`
- Fixed Jest mock hoisting issue in MCP client spec
- Passed validation pipeline:
  - `pnpm build`
  - `pnpm test`
  - `pnpm check-types`
  - `pnpm lint`

## Why
This enables the backend to act as both:
- **MCP consumer** (use remote/local MCP tools in agent flow), and
- **MCP provider** (serve internal tools over stdio),
while keeping setup practical for local Docker + OpenAI testing.
